### PR TITLE
Updating L2 and L3 VirtualNetwork examples to work with 24.12.x.

### DIFF
--- a/docs/examples/l2-vnet.yaml
+++ b/docs/examples/l2-vnet.yaml
@@ -1,15 +1,13 @@
----
 apiVersion: services.eda.nokia.com/v1alpha1
 kind: VirtualNetwork
 metadata:
   name: vnet1
+  namespace: eda
 spec:
   bridgeDomains:
     - name: bd1
       spec:
-        vniPool: vni-pool
         eviPool: evi-pool
-        tunnelIndexPool: tunnel-index-pool
         l2proxyARPND:
           dynamicLearning:
             ageTime: 2000
@@ -21,16 +19,24 @@ spec:
             monitoringWindow: 10
             numMoves: 4
           proxyARP: true
+          proxyND: false
+          tableSize: 250
+        macAging: 300
+        tunnelIndexPool: tunnel-index-pool
+        type: EVPNVXLAN
+        vniPool: vni-pool
   vlans:
     - name: storage
       spec:
         bridgeDomain: bd1
-        interfaceSelector: ["eda.nokia.com/edgeLinkType=storage"]
+        interfaceSelector:
+          - eda.nokia.com/edgeLinkType=storage
+        vlanID: pool
         vlanPool: vlan-pool
     - name: compute
       spec:
         bridgeDomain: bd1
-        interfaceSelector: ["eda.nokia.com/edgeLinkType=compute"]
+        interfaceSelector:
+          - eda.nokia.com/edgeLinkType=compute
+        vlanID: pool
         vlanPool: vlan-pool
----
-

--- a/docs/examples/l3-vnet.yaml
+++ b/docs/examples/l3-vnet.yaml
@@ -3,81 +3,120 @@ apiVersion: services.eda.nokia.com/v1alpha1
 kind: VirtualNetwork
 metadata:
   name: vnet2
+  namespace: eda
 spec:
-  routers:
-    - name: routetable1
-      spec:
-        routerID: 5.4.3.2
-        vniPool: vni-pool
-        eviPool: evi-pool
-        tunnelIndexPool: tunnel-index-pool
   bridgeDomains:
     - name: app1
       spec:
-        vniPool: vni-pool
         eviPool: evi-pool
+        macAging: 300
         tunnelIndexPool: tunnel-index-pool
+        type: EVPNVXLAN
+        vniPool: vni-pool
     - name: app2
       spec:
-        vniPool: vni-pool
         eviPool: evi-pool
+        macAging: 300
         tunnelIndexPool: tunnel-index-pool
+        type: EVPNVXLAN
+        vniPool: vni-pool
   irbInterfaces:
     - name: irb1
       spec:
-        bridgeDomain: app1
-        router: routetable1
+        arpTimeout: 14400
         bfd:
           desiredMinTransmitInt: 150002
           detectionMultiplier: 4
           enabled: true
+          minEchoReceiveInterval: 1000000
           requiredMinReceive: 150000
+        bridgeDomain: app1
         evpnRouteAdvertisementType:
-          arpStatic: true
           arpDynamic: true
+          arpStatic: true
+          ndDynamic: false
+          ndStatic: false
         hostRoutePopulate:
           dynamic: true
           evpn: true
-        ipv4Addresses:
-          - ipPrefix: 13.3.3.1/24
-            primary: true
-          - ipPrefix: 14.4.4.1/24
-        ipv6Addresses:
-          - ipPrefix: fc00:31::1/120
-            primary: true
-          - ipPrefix: fc00:41::1/120
+          static: false
+        ipAddresses:
+          - ipv4Address:
+              ipPrefix: 13.3.3.1/24
+              primary: true
+            ipv6Address:
+              ipPrefix: fc00:31::1/120
+              primary: true
+          - ipv4Address:
+              ipPrefix: 14.4.4.1/24
+              primary: false
+            ipv6Address:
+              ipPrefix: fc00:41::1/120
+              primary: false
+        ipMTU: 1500
+        l3ProxyARPND:
+          proxyARP: false
+          proxyND: false
+        learnUnsolicited: NONE
+        router: routetable1
     - name: irb2
       spec:
-        bridgeDomain: app2
-        router: routetable1
+        arpTimeout: 14400
         bfd:
           desiredMinTransmitInt: 150002
           detectionMultiplier: 4
           enabled: true
+          minEchoReceiveInterval: 1000000
           requiredMinReceive: 150000
+        bridgeDomain: app2
         evpnRouteAdvertisementType:
-          arpStatic: true
           arpDynamic: true
+          arpStatic: true
+          ndDynamic: false
+          ndStatic: false
         hostRoutePopulate:
           dynamic: true
-          static: false
           evpn: true
-        ipv4Addresses:
-          - ipPrefix: 15.3.3.1/24
-            primary: true
-          - ipPrefix: 16.4.4.1/24
-        ipv6Addresses:
-          - ipPrefix: fc00:51::1/120
-            primary: true
-          - ipPrefix: fc00:61::1/120
+          static: false
+        ipAddresses:
+          - ipv4Address:
+              ipPrefix: 15.3.3.1/24
+              primary: true
+            ipv6Address:
+              ipPrefix: fc00:51::1/120
+              primary: true
+          - ipv4Address:
+              ipPrefix: 16.4.4.1/24
+              primary: false
+            ipv6Address:
+              ipPrefix: fc00:61::1/120
+              primary: false
+        ipMTU: 1500
+        l3ProxyARPND:
+          proxyARP: false
+          proxyND: false
+        learnUnsolicited: NONE
+        router: routetable1
+  routers:
+    - name: routetable1
+      spec:
+        eviPool: evi-pool
+        routerID: 5.4.3.2
+        tunnelIndexPool: tunnel-index-pool
+        type: EVPNVXLAN
+        vniPool: vni-pool
   vlans:
     - name: vlan1
       spec:
         bridgeDomain: app1
-        interfaceSelector: ["eda.nokia.com/edgeLinkType=storage"]
+        interfaceSelector:
+          - eda.nokia.com/edgeLinkType=storage
+        vlanID: pool
         vlanPool: vlan-pool
     - name: vlan2
       spec:
         bridgeDomain: app2
-        interfaceSelector: ["eda.nokia.com/edgeLinkType=compute"]
+        interfaceSelector:
+          - eda.nokia.com/edgeLinkType=compute
+        vlanID: pool
         vlanPool: vlan-pool


### PR DESCRIPTION
- Removed "document start" indicator at the bottom of L2 Vnet
- Reformatted labels in both examples
- L3 vnet IP addressing changed format.