### PR TITLE
Added default credentials to try-eda.md

### DIFF
--- a/docs/getting-started/try-eda.md
+++ b/docs/getting-started/try-eda.md
@@ -155,6 +155,11 @@ To deliver the "Try EDA" experience, we have created an [EDA playground][playgro
     ```
 
     1. The `10.10.1.1` IP in this output matches what you provided in the `EXT_DOMAIN_NAME` environment variable.
+  
+    Open your web browser and navigate to provided URL to access the EDA UI. As you would expect, credentials are required in order to log in.
+    The default credentials are as follow:
+    * Username: `admin`  
+    * Password: `admin`  
 
     > While EDA UI offers an easy graphical way to manage the platform and automate your infrastructure, the usage of it is optional; you can interact with EDA API [directly](../development/api/index.md), or by leveraging the [CLI tools](../user-guide/using-the-clis.md). And you can even use the K8s API to manage EDA, for example, via `kubectl`.
 


### PR DESCRIPTION
This update adds a short section to the "Try EDA" documentation specifying the default web UI credentials (admin/admin). Had me guessing a few username/password combination before I could log in.  